### PR TITLE
fix: support new react-native architecture

### DIFF
--- a/ios/RNExitApp/RNExitApp.h
+++ b/ios/RNExitApp/RNExitApp.h
@@ -1,13 +1,13 @@
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
-#elif __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
+#elif __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
 #else
-#import "React/RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #endif
 
 #if RCT_NEW_ARCH_ENABLED
-#import <React-Codegen/RNExitAppSpec/RNExitAppSpec.h>
+#import <ReactCodegen/RNExitAppSpec/RNExitAppSpec.h>
 #endif
 
 @interface RNExitApp : NSObject <RCTBridgeModule>

--- a/ios/RNExitApp/RNExitApp.mm
+++ b/ios/RNExitApp/RNExitApp.mm
@@ -3,7 +3,7 @@
 #import "RNExitApp.h"
 
 #if RCT_NEW_ARCH_ENABLED
-#import <RNExitAppSpec/RNExitAppSpec.h>
+#import <ReactCodegen/RNExitAppSpec/RNExitAppSpec.h>
 #endif
 
 @implementation RNExitApp

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-exit-app",
+  "name": "@divvi/react-native-exit-app",
   "version": "2.0.0",
   "description": "Exit,close,kill,shutdown app completely for React Native on iOS and Android.",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wumke/react-native-exit-app"
+    "url": "git+https://github.com/divvixyz/react-native-exit-app.git"
   },
   "types": "index.d.ts",
   "keywords": [
@@ -24,15 +24,15 @@
   "author": "Wumke",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wumke/react-native-exit-app/issues"
+    "url": "https://github.com/divvixyz/react-native-exit-app/issues"
   },
-  "homepage": "https://github.com/wumke/react-native-exit-app",
+  "homepage": "https://github.com/divvixyz/react-native-exit-app",
   "codegenConfig": {
     "name": "RNExitAppSpec",
     "type": "modules",
     "jsSrcsDir": ".",
     "android": {
-      "javaPackageName": "com.github.wumke.RNExitApp"
+      "javaPackageName": "com.github.divvi.RNExitApp"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "type": "modules",
     "jsSrcsDir": ".",
     "android": {
-      "javaPackageName": "com.github.divvi.RNExitApp"
+      "javaPackageName": "com.github.wumke.RNExitApp"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divvi/react-native-exit-app",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Exit,close,kill,shutdown app completely for React Native on iOS and Android.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

This patch applies the changes from https://github.com/wumke/react-native-exit-app/issues/71#issuecomment-2497071024 and https://github.com/wumke/react-native-exit-app/issues/71#issuecomment-2596196932, resulting in support for React Native's new architecture.

### Testing

- Tested locally by applying the same changes via [`patch-package`](https://www.npmjs.com/package/patch-package) in a repo using [`@divvi/mobile`](https://www.npmjs.com/package/@divvi/mobile) and building for iOS.